### PR TITLE
Utilize auto-loading

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,6 @@
   "imports": {
     "@prisma/client": "npm:@prisma/client@^5.20.0",
     "@std/assert": "jsr:@std/assert@1",
-    "@std/dotenv": "jsr:@std/dotenv@^0.225.2",
     "@std/path": "jsr:@std/path@^1.0.6",
     "prisma": "npm:prisma@^5.20.0"
   },

--- a/main_test.ts
+++ b/main_test.ts
@@ -1,7 +1,4 @@
-import { load } from "@std/dotenv";
-
-await load();
-
+import "jsr:@std/dotenv@^0.225.2/load";
 import { assertEquals } from "@std/assert";
 import { prisma, Prisma } from "./prisma/client.ts";
 


### PR DESCRIPTION
I tried cloning the repo, following the directions in the README, and running `deno task test`. I got an error that said something about not being able to find the `DATABASE_URL` environment variable:

```
code/deno-with-prisma » deno task test
Task test deno test -A
running 1 test from ./main_test.ts
test ... FAILED (2ms)

 ERRORS

test => ./main_test.ts:8:6
error: PrismaClientInitializationError:
Invalid `prisma.user.findMany()` invocation:


error: Environment variable not found: DATABASE_URL.
  -->  schema.prisma:10
   |
 9 |   provider = "sqlite"
10 |   url      = env("DATABASE_URL")
   |

Validation Error Count: 1
    at Mn.handleRequestError (file:///Users/adamzerner/code/deno-with-prisma/prisma/generated/client/runtime/library.cjs:121:8053)
    at Mn.handleAndLogRequestError (file:///Users/adamzerner/code/deno-with-prisma/prisma/generated/client/runtime/library.cjs:121:7061)
    at Mn.request (file:///Users/adamzerner/code/deno-with-prisma/prisma/generated/client/runtime/library.cjs:121:6745)
    at async l (file:///Users/adamzerner/code/deno-with-prisma/prisma/generated/client/runtime/library.cjs:130:9633)
    at async test (file:///Users/adamzerner/code/deno-with-prisma/main_test.ts:13:17)

 FAILURES

test => ./main_test.ts:8:6

FAILED | 0 passed | 1 failed (4ms)

error: Test failed
code/deno-with-prisma »
```

I'm not sure why that error is occurring. I thought it might be because [`export`](https://jsr.io/@std/dotenv/doc/~/load#example_2) wasn't set to `true`, but even with `export: true` set I still got the error.

That lead me to search for docs on how environment variables work in Deno, which lead me to [this page](https://docs.deno.com/runtime/reference/env_variables/) which recommends using the [auto-import functionality](https://jsr.io/@std/dotenv/doc/~/load#example_1) of `@std/dotenv/load`. That resolved the issue for me and seems at least as idiomatic as the current approach.